### PR TITLE
fix download / tests that use the new Java version cache subdir

### DIFF
--- a/src/main/java/com/palantir/gradle/graal/DownloadGraalTask.java
+++ b/src/main/java/com/palantir/gradle/graal/DownloadGraalTask.java
@@ -55,8 +55,7 @@ public class DownloadGraalTask extends DefaultTask {
 
     @TaskAction
     public final void downloadGraal() throws IOException {
-        Path cache = getCacheSubdirectory().get();
-        Files.createDirectories(cache);
+        Files.createDirectories(getArchive().get().getAsFile().toPath().getParent());
 
         final String artifactPattern = isGraalRcVersion()
                 ? ARTIFACT_PATTERN_RC_VERSION : ARTIFACT_PATTERN_RELEASE_VERSION;
@@ -69,7 +68,8 @@ public class DownloadGraalTask extends DefaultTask {
     @OutputFile
     public final Provider<RegularFile> getArchive() {
         return getProject().getLayout()
-                .file(getCacheSubdirectory().map(dir -> dir.resolve(render(FILENAME_PATTERN)).toFile()));
+                .file(getCacheSubdirectory()
+                        .map(dir -> dir.resolve(javaVersion.get()).resolve(render(FILENAME_PATTERN)).toFile()));
     }
 
     @Input

--- a/src/main/java/com/palantir/gradle/graal/GraalVersionUtil.java
+++ b/src/main/java/com/palantir/gradle/graal/GraalVersionUtil.java
@@ -19,7 +19,7 @@ package com.palantir.gradle.graal;
 public final class GraalVersionUtil {
     public static boolean isGraalVersionGreatherThan19_3(String graalVersion) {
         try {
-            final String[] versionSplit = graalVersion.split("\\.");
+            final String[] versionSplit = graalVersion.split("\\.", -1);
             final int majorVersion = Integer.valueOf(versionSplit[0]);
             final int minorVersion = Integer.valueOf(versionSplit[1]);
             return majorVersion > 19 || (majorVersion == 19 && minorVersion >= 3);

--- a/src/test/groovy/com/palantir/gradle/graal/GradleGraalPluginIntegrationSpec.groovy
+++ b/src/test/groovy/com/palantir/gradle/graal/GradleGraalPluginIntegrationSpec.groovy
@@ -140,7 +140,7 @@ class GradleGraalPluginIntegrationSpec extends IntegrationSpec {
         server.takeRequest().path =~
                 "/oracle/graal/releases/download//vm-19.0.0/graalvm-ce-windows-amd64-19.0.0.zip"
 
-        file("cacheDir/19.0.0/8/graalvm-ce-java8-19.0.0-amd64.zip").text == '<<zip>>'
+        file("cacheDir/19.0.0/8/graalvm-ce-19.0.0-amd64.zip").text == '<<zip>>'
     }
 
     // for Windows the download is a .zip, this is tested below


### PR DESCRIPTION
The Java version sub-dir was missing in `DownloadGraalTask` and erroneously specified in a test. The `.split(..., -1)` is to silence an [Error Prone check](https://errorprone.info/bugpattern/StringSplitter).

Tests are passing on my windows machine now. Haven't checked a Unix yet.